### PR TITLE
Fix missing manifest for non-dev environments

### DIFF
--- a/lib/phoenix_vite/components.ex
+++ b/lib/phoenix_vite/components.ex
@@ -8,7 +8,7 @@ defmodule PhoenixVite.Components do
 
       <PhoenixVite.Components.assets
         names={["js/app.js", "css/app.css"]}
-        manifest={{:my_app, "priv/static/.vite/manifest.js"}}
+        manifest={{:my_app, "priv/static/.vite/manifest.json"}}
         dev_server={PhoenixVite.Components.has_vite_watcher?(MyAppWeb.Endpoint)}
       />
 
@@ -16,7 +16,7 @@ defmodule PhoenixVite.Components do
 
       <PhoenixVite.Components.assets
         names={["js/app.js", "css/app.css"]}
-        manifest={{:my_app, "priv/static/.vite/manifest.js"}}
+        manifest={{:my_app, "priv/static/.vite/manifest.json"}}
         dev_server={PhoenixVite.Components.has_vite_watcher?(MyAppWeb.Endpoint)}
         to_url={fn p -> static_url(@conn, p) end}
       />
@@ -111,14 +111,14 @@ defmodule PhoenixVite.Components do
       )
 
     ~H"""
-    <.reference_for_file :for={css <- @chunk["css"]} file={css} to_url={@to_url} cache />
-    <%= for chunk <- @imported_chunks, css <- chunk["css"] do %>
+    <.reference_for_file :for={css <- @chunk.css} file={css} to_url={@to_url} cache />
+    <%= for chunk <- @imported_chunks, css <- chunk.css do %>
       <.reference_for_file file={css} to_url={@to_url} cache />
     <% end %>
-    <.reference_for_file file={@chunk["file"]} to_url={@to_url} cache />
+    <.reference_for_file file={@chunk.file} to_url={@to_url} cache />
     <.reference_for_file
       :for={chunk <- @imported_chunks}
-      file={chunk}
+      file={chunk.file}
       rel="modulepreload"
       to_url={@to_url}
       cache

--- a/lib/phoenix_vite/igniter.ex
+++ b/lib/phoenix_vite/igniter.ex
@@ -131,7 +131,7 @@ if Code.ensure_loaded?(Igniter) do
             """
                 <PhoenixVite.Components.assets
                   names={["js/app.js", "css/app.css"]}
-                  manifest={{#{inspect(app_name)}, "priv/static/.vite/manifest.js"}}
+                  manifest={{#{inspect(app_name)}, "priv/static/.vite/manifest.json"}}
                   dev_server={PhoenixVite.Components.has_vite_watcher?(#{inspect(endpoint)})}
                   to_url={fn p -> static_url(@conn, p) end}
                 />

--- a/lib/phoenix_vite/manifest.ex
+++ b/lib/phoenix_vite/manifest.ex
@@ -64,7 +64,7 @@ defmodule PhoenixVite.Manifest do
   # https://vite.dev/guide/backend-integration.html
   def imported_chunks(%{} = manifest, name) do
     chunk = Map.fetch!(manifest, name)
-    imports = Map.get(chunk, "imports", [])
+    imports = chunk.imports
 
     {chunks, _seen} =
       Enum.reduce(imports, {[], MapSet.new()}, fn name, {acc_files, seen} ->
@@ -82,7 +82,7 @@ defmodule PhoenixVite.Manifest do
       {[], seen}
     else
       seen = MapSet.put(seen, name)
-      imports = Map.get(chunk, "imports", [])
+      imports = chunk.imports
 
       {chunks, seen} =
         Enum.reduce(imports, {[], seen}, fn name, {acc_chunks, seen} ->

--- a/test/phoenix_vite/igniter_test.exs
+++ b/test/phoenix_vite/igniter_test.exs
@@ -115,7 +115,7 @@ defmodule PhoenixVite.IgniterTest do
              12    - |    </script>
                 10 + |    <PhoenixVite.Components.assets
                 11 + |      names={["js/app.js", "css/app.css"]}
-                12 + |      manifest={{:test, "priv/static/.vite/manifest.js"}}
+                12 + |      manifest={{:test, "priv/static/.vite/manifest.json"}}
                 13 + |      dev_server={PhoenixVite.Components.has_vite_watcher?(TestWeb.Endpoint)}
                 14 + |      to_url={fn p -> static_url(@conn, p) end}
                 15 + |    />


### PR DESCRIPTION
Update Igniter script to use the correct manifest file Fixes accessing Chunk struct fields with string keys

- Replace Map.get(chunk, "imports", []) with chunk.imports in manifest.ex
- Replace chunk["css"], chunk["file"] with chunk.css, chunk.file in components.ex

Related with [issue](https://github.com/LostKobrakai/phoenix_vite/issues/3)