### PR TITLE
Update phoenix_vite dependency version to 0.2 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ by adding `phoenix_vite` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:phoenix_vite, "~> 0.2"}
+    {:phoenix_vite, "~> 0.2.0"}
   ]
 end
 ```


### PR DESCRIPTION
Follow-up to b05ebb9: Add version specification to README example