### PR TITLE
fix: remove cache param from modulepreload to prevent duplicate requests

### DIFF
--- a/lib/phoenix_vite/components.ex
+++ b/lib/phoenix_vite/components.ex
@@ -121,7 +121,6 @@ defmodule PhoenixVite.Components do
       file={chunk.file}
       rel="modulepreload"
       to_url={@to_url}
-      cache
     />
     """
   end


### PR DESCRIPTION
modulepreload tags with ?vsn=d query string cause browsers to load chunks twice: once from the preload tag and again from JS import statements which don't include the query parameter.

Before
<img width="600" alt="Before fix - duplicate chunks loaded" src="https://github.com/user-attachments/assets/a1080719-431c-43f2-ad8a-8cd6a3cf7956" />

After
<img width="600" alt="After fix - single chunk load" src="https://github.com/user-attachments/assets/980d9366-6646-4d2c-8297-568c41bdb630" />
