### PR TITLE
Support Typescript files in development mode

### DIFF
--- a/lib/phoenix_vite/components.ex
+++ b/lib/phoenix_vite/components.ex
@@ -133,7 +133,7 @@ defmodule PhoenixVite.Components do
   defp reference_for_file(assigns) do
     ~H"""
     <script
-      :if={Path.extname(@file) in [".js", ".ts"]}
+      :if={Path.extname(@file) in [".js", ".ts", ".jsx", ".tsx"]}
       phx-track-static
       type="module"
       src={@to_url.(cache_enabled_path(@file, @cache))}

--- a/lib/phoenix_vite/components.ex
+++ b/lib/phoenix_vite/components.ex
@@ -133,7 +133,7 @@ defmodule PhoenixVite.Components do
   defp reference_for_file(assigns) do
     ~H"""
     <script
-      :if={Path.extname(@file) == ".js"}
+      :if={Path.extname(@file) in [".js", ".ts"]}
       phx-track-static
       type="module"
       src={@to_url.(cache_enabled_path(@file, @cache))}


### PR DESCRIPTION
Currently in development if a file has the `.ts` extension it gets ignored. In `MIX_ENV=prod` it does inject the script tag for the JS generated by vite. The patch is simple its changing line 136 from this 
```elixir
:if={Path.extname(@file) == ".js"}
```
to this 
```elixir
:if={Path.extname(@file) in [".js", ".ts"]}
```