### PR TITLE
fix: load app.css before detecting tailwind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix installer failure when `assets/css/app.css` exists outside Igniter's loaded rewrite sources
+
 ## [0.5.0] - 2026-07-27
 
 - Fix heex warning for using rel attribute with `:global` [[#27](https://github.com/LostKobrakai/phoenix_vite/pull/27)]

--- a/lib/phoenix_vite/igniter.ex
+++ b/lib/phoenix_vite/igniter.ex
@@ -346,9 +346,12 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp has_tailwind?(igniter) do
-      if Igniter.exists?(igniter, "assets/css/app.css") do
-        {:ok, source} = Rewrite.source(igniter.rewrite, "assets/css/app.css")
-        tailwind_css?(Rewrite.Source.get(source, :content))
+      path = "assets/css/app.css"
+      igniter = Igniter.include_existing_file(igniter, path)
+
+      case Rewrite.source(igniter.rewrite, path) do
+        {:ok, source} -> tailwind_css?(Rewrite.Source.get(source, :content))
+        {:error, _error} -> false
       end
     end
 

--- a/test/phoenix_vite/igniter_test.exs
+++ b/test/phoenix_vite/igniter_test.exs
@@ -47,6 +47,21 @@ defmodule PhoenixVite.IgniterTest do
       });
       """)
     end
+
+    test "loads app.css when it exists outside of the rewrite sources" do
+      path = "assets/css/app.css"
+      igniter = phx_test_project()
+
+      assert Igniter.exists?(igniter, path)
+      igniter = %{igniter | rewrite: Rewrite.delete(igniter.rewrite, path)}
+      refute Rewrite.has_source?(igniter.rewrite, path)
+
+      igniter = ViteIgniter.create_vite_config(igniter)
+      {:ok, source} = Rewrite.source(igniter.rewrite, "assets/vite.config.mjs")
+
+      assert Rewrite.Source.get(source, :content) =~
+               ~s(import tailwindcss from "@tailwindcss/vite")
+    end
   end
 
   describe "configure_dev_server_static_url_for_development/3" do


### PR DESCRIPTION
This was reported by one of the users of live_vue which depends on phoenix_vite during it's installation.

In `phoenix_vite 0.5.0`, Tailwind detection checks whether `assets/css/app.css` exists with `Igniter.exists?/2`, then reads it directly from Rewrite. A file can exist on disk without being loaded into Rewrite, causing:

   ```text
   ** (MatchError) no match of right hand side value:
   {:error, %Rewrite.Error{reason: :nosource, path: "assets/css/app.css"}}
 ```

This affects both direct PhoenixVite installation and packages that compose its installer.

Fix

Load assets/css/app.css with Igniter.include_existing_file/2 before inspecting its contents. If the file is unavailable, Tailwind detection safely returns false. This preserves support for projects generated with --no-tailwind.

Reproduction

 ```bash
   mix phx.new myapp --no-install
   cd myapp
   mix igniter.install phoenix_vite
 ```

Testing

Added a regression test where app.css exists but is not present in Rewrite’s loaded sources.

 - mix test — 33 tests, 0 failures
 - mix checks — passed, including formatting, compilation, cycle detection, and Dialyzer